### PR TITLE
use HTTP_HOST instead of SERVER_NAME

### DIFF
--- a/src/util/helperFunctions.php
+++ b/src/util/helperFunctions.php
@@ -40,7 +40,7 @@ function redirect($url)
  */
 function getBaseUrl()
 {
-    $baseUrl = $_SERVER['SERVER_NAME'] . ":" . $_SERVER['SERVER_PORT'] . '/';
+    $baseUrl = $_SERVER['HTTP_HOST'] . '/';
     if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == "on") {
         $baseUrl = "https://" . $baseUrl;
     } else {


### PR DESCRIPTION
$_SERVER['HTTP_HOST'] is made from the header of the client's request, so it makes sense to use this variable. 
For localhost is no difference, but for sites like www.something.com, then $_SERVER['HTTP_HOST'] will return www.something.com, as opposed to $_SERVER['SERVER_NAME'] which would return just something.com

Another important point is that $_SERVER['HTTP_HOST'] will also contain the port if its different to the defaults 80 or 443. So it is not necessary anymore to append the port.